### PR TITLE
Use GitHub App token instead of default token

### DIFF
--- a/.github/ghalint.yml
+++ b/.github/ghalint.yml
@@ -1,4 +1,0 @@
-excludes:
-  - policy_name: checkout_persist_credentials_should_be_false
-    workflow_file_path: .github/workflows/release.yml
-    job_name: tagpr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,6 @@ permissions: {}
 jobs:
   tagpr:
     name: 🔖 Release a New Version
-    permissions:
-      contents: write
-      pull-requests: write
     runs-on: Ubuntu-Latest
     timeout-minutes: 1
     outputs:
@@ -23,7 +20,16 @@ jobs:
       - name: 🚚 Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          persist-credentials: true
+          persist-credentials: false
+
+      - name: 💳 Create GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: 🔖 Release a new version
         id: tagpr
@@ -31,7 +37,7 @@ jobs:
         with:
           config: .github/tagpr.ini
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   deploy:
     name: 🚀 Deploy to Production


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

### ⚠️ Issue

close #

<br />

### ✏️ Description

It will fire workflows that can't be with the default token.

<!--
A clear and concise description
  - Why did you make this change?
  - Please describe how this method is better than others.
-->

<br />

- [x] I agree to follow the [Code of Conduct](https://github.com/5ouma/mobicard/blob/main/.github/CODE_OF_CONDUCT.md).
